### PR TITLE
Modified the pipeline to make it read the fits header as dictionary i…

### DIFF
--- a/pyTANSPEC/reduce_specXD.py
+++ b/pyTANSPEC/reduce_specXD.py
@@ -1224,7 +1224,7 @@ def CreateLogFilesFromFits_subrout(PC,hdu=0):
                 for hkeys in LogColumns :   #Capture if these keywords are missing in header, and replace with -NA-
                     if hkeys not in prihdr : prihdr[hkeys]='-NA-'
                 
-                outfile.write(img+' '+RowString.format(**prihdr)+' {0}\n'.format(i))
+                outfile.write(img+' '+RowString.format(**dict(prihdr))+' {0}\n'.format(i))
         os.chdir(PC.RAWDATADIR)
     print("{0} saved in each night's directory. Edit in manually for errors like ACTIVE filter.".format(LogFilename))
 


### PR DESCRIPTION
The pipeline was identifing the fits header as list. pyTANSPEC couldn't read the files which is returned from HxRGproc because of same keywords. Here is the error message.

`File "/home/varghese/pyENV310/bin/pyxdspec", line 33, in <module>
    sys.exit(load_entry_point('pyTANSPEC==0.0.1', 'console_scripts', 'pyxdspec')())
  File "/home/varghese/pyENV310/lib/python3.10/site-packages/pyTANSPEC/reduce_specXD.py", line 1808, in main
    Instrument.Steps[task]['function'](PC)
  File "/home/varghese/pyENV310/lib/python3.10/site-packages/pyTANSPEC/reduce_specXD.py", line 1227, in CreateLogFilesFromFits_subrout
    outfile.write(img+' '+RowString.format(**prihdr)+' {0}\n'.format(i))
TypeError: str.format() got multiple values for keyword argument 'HISTORY'`

The code is modified to read the header as dictionary. So, it can handle files from HxRGproc.

